### PR TITLE
Fix/find cursor

### DIFF
--- a/spec/datastore.spec.ts
+++ b/spec/datastore.spec.ts
@@ -44,87 +44,95 @@ describe("testing the datastore", () => {
     const UserStorage = new MockStorageDriver("users");
     const Users = new Datastore({storage: UserStorage, generateId: true});
 
+   /* test("loading in first user", () => {
+        expect.assertions(1);
+        return Users.insert({name: "m", age: 24})
+            .then((res) => {
+                expect(res).toEqual(2);
+            });
+    });*/
+
     test("loading users name index into the datastore from disk", () => {
         expect.assertions(1);
         let index: any[];
         return UserStorage.fetchIndex("name")
-        .then((indexArray) => {
-            index = indexArray;
-            return Users.ensureIndex({fieldName: "name", unique: true});
-        })
-        .then(() => {
-            return Users.insertIndex("name", index);
-        })
-        .then(() => {
-            return Users.getIndices();
-        })
-        .then((indices) => {
-            const ind: Index = indices.get("name");
-            if (ind) {
-                return ind.toJSON();
-            } else {
-                throw new Error("No index for name");
-            }
-        })
-        .then((res) => {
-            const nameJSON: string = JSON.parse(res);
-            expect(nameJSON).toEqual(expect.arrayContaining([{ key: "Marcus", value: ["T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9"]}, { key: "Scott", value: ["UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]}, { key: "Gavin", value: ["UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"]}, { key: "Smith", value: ["UCtUQVJWd0JBQUE9cHE1SmpnSE44eDQ9Rko2RmlJeHJrR1E9ZkN4cjROblB1WEU9"]}, { key: "Kevin", value: ["UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9"]}, { key: "Mark", value: ["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9"]}, { key: "Francis", value: ["UE9UQVJWd0JBQUE9cmZ4Y2MxVzNlOFk9TXV4dmJ0WU5JUFk9d0FkMW1oSHY2SWs9"]}, { key: "Luke", value: ["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]}, { key: "Morgan", value: ["UCtUQVJWd0JBQUE9dnVrRm1xWmJDVTQ9aGR2VjN0Z1gvK009dVpUVzMrY3N4eDg9"]}]));
-        });
+            .then((indexArray) => {
+                index = indexArray;
+                return Users.ensureIndex({fieldName: "name", unique: true});
+            })
+            .then(() => {
+                return Users.insertIndex("name", index);
+            })
+            .then(() => {
+                return Users.getIndices();
+            })
+            .then((indices) => {
+                const ind: Index = indices.get("name");
+                if (ind) {
+                    return ind.toJSON();
+                } else {
+                    throw new Error("No index for name");
+                }
+            })
+            .then((res) => {
+                const nameJSON: string = JSON.parse(res);
+                expect(nameJSON).toEqual(expect.arrayContaining([{ key: "Marcus", value: ["T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9"]}, { key: "Scott", value: ["UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]}, { key: "Gavin", value: ["UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"]}, { key: "Smith", value: ["UCtUQVJWd0JBQUE9cHE1SmpnSE44eDQ9Rko2RmlJeHJrR1E9ZkN4cjROblB1WEU9"]}, { key: "Kevin", value: ["UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9"]}, { key: "Mark", value: ["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9"]}, { key: "Francis", value: ["UE9UQVJWd0JBQUE9cmZ4Y2MxVzNlOFk9TXV4dmJ0WU5JUFk9d0FkMW1oSHY2SWs9"]}, { key: "Luke", value: ["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]}, { key: "Morgan", value: ["UCtUQVJWd0JBQUE9dnVrRm1xWmJDVTQ9aGR2VjN0Z1gvK009dVpUVzMrY3N4eDg9"]}]));
+            });
     });
 
     test("loading users age index into the datastore from disk", () => {
         expect.assertions(1);
         let index: any[]; // will hold the array of objects of indices
         return UserStorage.fetchIndex("age")
-        .then((indexArray) => {
-            index = indexArray;
-            return Users.ensureIndex({fieldName: "age", unique: true});
-        })
-        .then(() => {
-            return Users.insertIndex("age", index);
-        })
-        .then(() => {
-            return Users.getIndices();
-        })
-        .then((indices) => {
-            const ind: Index = indices.get("age");
-            if (ind) {
-                return ind.toJSON();
-            } else {
-                throw new Error("No index for age");
-            }
-        })
-        .then((res) => {
-            const ageJSON: string = JSON.parse(res);
-            expect(ageJSON).toEqual(expect.arrayContaining([{ key: 27, value: ["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9"]}, { key: 35, value: ["UCtUQVJWd0JBQUE9cHE1SmpnSE44eDQ9Rko2RmlJeHJrR1E9ZkN4cjROblB1WEU9"]}, { key: 22, value: ["UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9"]}, { key: 39, value: ["UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]}, { key: 25, value: ["UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"]}, { key: 28, value: ["UE9UQVJWd0JBQUE9cmZ4Y2MxVzNlOFk9TXV4dmJ0WU5JUFk9d0FkMW1oSHY2SWs9"]}, { key: 0, value: ["T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9"]}, { key: 26, value: ["UCtUQVJWd0JBQUE9dnVrRm1xWmJDVTQ9aGR2VjN0Z1gvK009dVpUVzMrY3N4eDg9"]}, { key: 1, value: ["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]}]));
-        });
+            .then((indexArray) => {
+                index = indexArray;
+                return Users.ensureIndex({fieldName: "age", unique: true});
+            })
+            .then(() => {
+                return Users.insertIndex("age", index);
+            })
+            .then(() => {
+                return Users.getIndices();
+            })
+            .then((indices) => {
+                const ind: Index = indices.get("age");
+                if (ind) {
+                    return ind.toJSON();
+                } else {
+                    throw new Error("No index for age");
+                }
+            })
+            .then((res) => {
+                const ageJSON: string = JSON.parse(res);
+                expect(ageJSON).toEqual(expect.arrayContaining([{ key: 27, value: ["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9"]}, { key: 35, value: ["UCtUQVJWd0JBQUE9cHE1SmpnSE44eDQ9Rko2RmlJeHJrR1E9ZkN4cjROblB1WEU9"]}, { key: 22, value: ["UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9"]}, { key: 39, value: ["UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]}, { key: 25, value: ["UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"]}, { key: 28, value: ["UE9UQVJWd0JBQUE9cmZ4Y2MxVzNlOFk9TXV4dmJ0WU5JUFk9d0FkMW1oSHY2SWs9"]}, { key: 0, value: ["T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9"]}, { key: 26, value: ["UCtUQVJWd0JBQUE9dnVrRm1xWmJDVTQ9aGR2VjN0Z1gvK009dVpUVzMrY3N4eDg9"]}, { key: 1, value: ["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]}]));
+            });
     });
 
     test("getting a user object and a friend", () => {
         expect.assertions(6);
         return Users.getIndices()
-        .then((indices) => {
-            const IndexName = indices.get("name");
-            if (IndexName) {
-                return IndexName.search("Scott");
-            } else {
-                throw new Error("No Index for name");
-            }
-        })
-        .then((id) => {
-            return UserStorage.getItem(id[0]);
-        })
-        .then((user) => {
-            expect(user.name).toEqual("Scott");
-            expect(user.age).toEqual(39);
-            expect(user.friends).toEqual(expect.arrayContaining(["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9", "UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]));
-            return UserStorage.getItem(user.friends[0]);
-        })
-        .then((user) => {
-            expect(user.name).toEqual("Mark");
-            expect(user.age).toEqual(27);
-            expect(user.friends).toEqual(expect.arrayContaining(["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9", "UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]));
-        });
+            .then((indices) => {
+                const IndexName = indices.get("name");
+                if (IndexName) {
+                    return IndexName.search("Scott");
+                } else {
+                    throw new Error("No Index for name");
+                }
+            })
+            .then((id) => {
+                return UserStorage.getItem(id[0]);
+            })
+            .then((user) => {
+                expect(user.name).toEqual("Scott");
+                expect(user.age).toEqual(39);
+                expect(user.friends).toEqual(expect.arrayContaining(["UHVUQVJWd0JBQUE9ZkZTNFRzQ0YwRVE9QTBRaUpUWjFJQ0U9UlRsNVg3MHNPcFE9", "UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9"]));
+                return UserStorage.getItem(user.friends[0]);
+            })
+            .then((user) => {
+                expect(user.name).toEqual("Mark");
+                expect(user.age).toEqual(27);
+                expect(user.friends).toEqual(expect.arrayContaining(["UCtUQVJWd0JBQUE9TVMrYjRpWVUrTEk9cWpON01RWGlQWjA9c1NWQzBacFNqakE9", "UGVUQVJWd0JBQUE9R2JkWG9UUlErcDg9cUdSOU5CMnNwR0U9ZmpkUzVuZmhIWE09"]));
+            });
     });
 
     test("retrieving generated _id Date of user", () => {
@@ -166,18 +174,33 @@ describe("testing the datastore", () => {
             });
     });
 
-    /*test("finding 5 out of 10 users sorted by age", () => {
-     expect.assertions(1);
-     return Users.find({})
-        .exec()
-        .then((res) => {
-            console.log(res);
-            expect(res).toEqual(expect.arrayContaining(["hello"]));
-        });
-    });*/
+    test("finding all users", () => {
+        expect.assertions(1);
+        return Users.find({})
+            .exec()
+            .then((res) => {
+                expect(res.length).toEqual(9);
+            });
+    });
 
-    /*
-     WORKS !!!! keep
+    test("finding all users age 22-28", () => {
+       expect.assertions(1);
+       return Users.find({age: {$gte: 22, $lte: 28}})
+            .exec()
+            .then((res) => {
+                expect(res.length).toEqual(5);
+            });
+    });
+
+    test("finding one user by ID", () => {
+        expect.assertions(1);
+        return Users.find({_id: "T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9"})
+            .exec()
+            .then((res) => {
+                expect(res).toEqual(expect.arrayContaining([{_id: "T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9", age: 0, friends: ["UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9", "UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"], name: "Marcus"}]));
+            });
+    });
+
     test("clear the datastore users", () => {
         expect.assertions(1);
         return UserStorage.clear()
@@ -185,18 +208,28 @@ describe("testing the datastore", () => {
                 const exists = fs.existsSync(`${CWD}/spec/example/db/users`);
                 expect(exists).toBe(false);
             });
-    });*/
+    });
 });
 
 // new describe here with new datastore
 /*describe("creating new datastore", () => {
- const LangStorage = new MockStorageDriver("langs");
- const Langs = new Datastore({storage: LangStorage, generateId: true});
- });*/
+    const LangStorage = new MockStorageDriver("langs");
+    const Langs = new Datastore({storage: LangStorage, generateId: true});
+    test("hmm", () => {
+        expect.assertions(1);
+        return Langs.insert({name: "hmm"})
+            .then((res) => {
+                console.log(res);
+                expect(res).toEqual(3);
+            });
+    });
+});*/
 
 afterAll(() => {
     console.log("end");
     const cwd = process.cwd();
-    // const files = fs.readdirSync(`${cwd}/spec/example/db`);
-    // files.map((file) => fs.unlinkSync(`${cwd}/spec/example/db/${file}`));
+    // clear users
+    /*const files = fs.readdirSync(`${cwd}/spec/example/db/users`);
+    files.map((file) => fs.unlinkSync(`${cwd}/spec/example/db/users/${file}`));
+    fs.rmdirSync(`${cwd}/spec/example/db/users`);*/
 });

--- a/spec/datastore.spec.ts
+++ b/spec/datastore.spec.ts
@@ -42,15 +42,7 @@ describe("testing the datastore", () => {
     // loads initial users db
     const CWD = process.cwd();
     const UserStorage = new MockStorageDriver("users");
-    const Users = new Datastore({storage: UserStorage, generateId: true});
-
-   /* test("loading in first user", () => {
-        expect.assertions(1);
-        return Users.insert({name: "m", age: 24})
-            .then((res) => {
-                expect(res).toEqual(2);
-            });
-    });*/
+    const Users = new Datastore({storage: UserStorage});
 
     test("loading users name index into the datastore from disk", () => {
         expect.assertions(1);
@@ -201,10 +193,36 @@ describe("testing the datastore", () => {
             });
     });
 
+    test("the cursor no index", () => {
+        expect.assertions(2);
+        return Users.find({})
+            .sort({age: -1})
+            .skip(1)
+            .limit(2)
+            .exec()
+            .then((res) => {
+                expect(res).toEqual(expect.arrayContaining([ { _id: "UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9", name: "Gavin", age: 25, friends: [ "T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9", "UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9" ] }, { _id: "UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9", name: "Kevin", age: 22, friends: ["T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9", "UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9"]}]));
+                expect(res.length).toEqual(2);
+            });
+    });
+
+    test("the cursor with index", () => {
+        expect.assertions(2);
+        return Users.find({age: {$gt: 1}})
+            .sort({age: 1})
+            .skip(1)
+            .limit(2)
+            .exec()
+            .then((res) => {
+                expect(res).toEqual(expect.arrayContaining([ { _id: "UHVUQVJWd0JBQUE9TVJpdzRYUUtZMGc9Wk1tM0Rla0hvem89UXBXaTRETjgxVHc9", name: "Gavin", age: 25, friends: [ "T2VUQVJWd0JBQUE9VTNrcTlIMSt4Qjg9R0RvWVl2SkhXMmc9TkUzZlF6a2ZxaDA9", "UHVUQVJWd0JBQUE9QVlxckkraExMWUU9VkxGZjUyZi9OMmc9S0NFVy85bHlnMHM9" ] }, { _id: "UCtUQVJWd0JBQUE9dnVrRm1xWmJDVTQ9aGR2VjN0Z1gvK009dVpUVzMrY3N4eDg9", name: "Morgan", age: 26, friends: [ "UE9UQVJWd0JBQUE9cmZ4Y2MxVzNlOFk9TXV4dmJ0WU5JUFk9d0FkMW1oSHY2SWs9", "UCtUQVJWd0JBQUE9cHE1SmpnSE44eDQ9Rko2RmlJeHJrR1E9ZkN4cjROblB1WEU9"]}]));
+                expect(res.length).toEqual(2);
+            });
+    });
+
     test("clear the datastore users", () => {
         expect.assertions(1);
         return UserStorage.clear()
-            .then((res) => {
+            .then(() => {
                 const exists = fs.existsSync(`${CWD}/spec/example/db/users`);
                 expect(exists).toBe(false);
             });

--- a/spec/example/exampleStorageDriver.ts
+++ b/spec/example/exampleStorageDriver.ts
@@ -136,11 +136,31 @@ export class MockStorageDriver implements IStorageDriver {
         });
     }
     /**
-     *
+     * Need to have a collection scan. Go over every file in the directory
+     * get the Id, pull the dock out an put into iteratorCallback for each file.
      */
-    public iterate(iteratorCallback: (key: string, value: any, iteratorNumber: number) => any): Promise<any> {
+    public iterate(iteratorCallback: (key: string, value: any, iteratorNumber?: number) => any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            resolve();
+            const cwd = process.cwd();
+            fs.readdir(`${cwd}/spec/example/db/${this.filePath}`, (err: ErrnoException, files) => {
+                if (err) {
+                    return reject(err);
+                }
+                for (let i = files.length - 1; i >= 0; i--) {
+                    try {
+                        const data = fs.readFileSync(`${cwd}/spec/example/db/${this.filePath}/${files[i]}`).toString();
+                        if (data) {
+                            const doc = JSON.parse(data);
+                            if (doc.hasOwnProperty("_id")) {
+                                iteratorCallback(doc, doc._id);
+                            }
+                        }
+                    } catch (e) {
+                        return reject(e);
+                    }
+                }
+                resolve();
+            });
         });
     }
     /**

--- a/spec/example/exampleStorageDriver.ts
+++ b/spec/example/exampleStorageDriver.ts
@@ -172,7 +172,7 @@ export class MockStorageDriver implements IStorageDriver {
         });
     }
     /**
-     * unlink file, if associated index files also unlink
+     * Clear collection
      */
     public clear(): Promise<null> {
         return new Promise<null>((resolve, reject) => {

--- a/spec/utils/misc.spec.ts
+++ b/spec/utils/misc.spec.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from "../../src/utlis";
+import { isEmpty, getSortType, mergeSort } from "../../src/utlis";
 
 describe("testing miscellaneous methods", () => {
 
@@ -22,5 +22,51 @@ describe("testing miscellaneous methods", () => {
         expect(isEmpty(ar)).toBe(false);
         expect(isEmpty(object)).toBe(false);
         expect(isEmpty(st)).toBe(false);
+    });
+
+    test("sortObj", () => {
+        const test1 = { sort: { name: -1 }};
+        const test1key = Object.keys(test1.sort)[0];
+        const test1v = test1.sort[test1key];
+        const test2 = { sort: { age: -1 }};
+        const test2key = Object.keys(test2.sort)[0];
+        const test2v = test2.sort[test2key];
+        const test3 = { sort: { date: -1 }};
+        const test3key = Object.keys(test3.sort)[0];
+        const test3v = test3.sort[test3key];
+        const test4 = { sort: { age: 1 }};
+        const test4key = Object.keys(test4.sort)[0];
+        const test4v = test4.sort[test4key];
+        const test5 = { sort: { date: 1}};
+        const test5key = Object.keys(test5.sort)[0];
+        const test5v = test5.sort[test5key];
+
+        const testers = [
+            {name: "a", age: 1, date: new Date("1/2/2017") },
+            {name: "c", age: 6, date: new Date("1/1/2017") },
+            {name: "b", age: 5, date: new Date("1/4/2017") },
+        ];
+
+        const type1 = getSortType(testers, test1key);
+        const type2 = getSortType(testers, test2key);
+        const type3 = getSortType(testers, test3key);
+        const type4 = getSortType(testers, test4key);
+        const type5 = getSortType(testers, test5key);
+
+        expect(mergeSort(testers, test3key, test3v, type3)).toEqual(expect.arrayContaining([ { name: "b", age: 5, date: new Date("1/4/2017") },
+        { name: "a", age: 1, date: new Date("1/2/2017") },
+        { name: "c", age: 6, date: new Date("1/1/2017") } ]));
+        expect(mergeSort(testers, test5key, test5v, type5)).toEqual(expect.arrayContaining([ { name: "c", age: 6, date: new Date("1/1/2017") },
+        { name: "a", age: 1, date: new Date("1/2/2017") },
+        { name: "b", age: 5, date: new Date("1/4/2017") } ]));
+        expect(mergeSort(testers, test1key, test1v, type1)).toEqual(expect.arrayContaining([ { name: "c", age: 6, date: new Date("1/1/2017") },
+        { name: "b", age: 5, date: new Date("1/4/2017") },
+        { name: "a", age: 1, date: new Date("1/2/2017") } ]));
+        expect(mergeSort(testers, test2key, test2v, type2)).toEqual(expect.arrayContaining([ { name: "c", age: 6, date: new Date("1/1/2017") },
+        { name: "b", age: 5, date: new Date("1/4/2017") },
+        { name: "a", age: 1, date: new Date("1/2/2017") } ]));
+        expect(mergeSort(testers, test4key, test4v, type4)).toEqual(expect.arrayContaining([ { name: "a", age: 1, date: new Date("1/2/2017") },
+        { name: "b", age: 5, date: new Date("1/4/2017") },
+        { name: "c", age: 6, date: new Date("1/1/2017") } ]));
     });
 });

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -81,7 +81,7 @@ export default class Cursor implements ICursor {
             const promisesGetIds: Array<Promise<string[]>> = [];
 
             if (isEmpty(this.query)) {
-                promisesGetIds.push();
+                promisesGetIds.push(this.datastore.search());
             } else {
                 for (const field in this.query) {
                     if (this.query.hasOwnProperty(field)) {

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -3,9 +3,8 @@
  */
 import Index from "./indices";
 import { IindexOptions, IStorageDriver, IRange, IupdateOptions } from "./types";
-import Cursor from "./cursor";
-import { getPath } from "./utlis/get_path";
-import { getUUID, getDate } from "./utlis/id_hasher";
+import { Cursor, Ioptions} from "../src";
+import { isEmpty, getPath, getUUID, getDate } from "./utlis";
 import * as BTT from "binary-type-tree";
 
 export interface IDatastore {
@@ -18,7 +17,7 @@ export interface IDatastore {
     removeIndex(options: IindexOptions): Promise<null>;
     insertIndex(key: string, index: any[]): Promise<null>;
     getIndices(): Promise<any>;
-    getDocs(ids: string | string[]): Promise<any[]>;
+    getDocs(options: Ioptions, ids: string | string[]): Promise<any[]>;
     search(fieldName: string, value: any): Promise<string[]>;
 }
 
@@ -38,9 +37,9 @@ export default class Datastore implements IDatastore {
     /**
      * @param config - config object `{storage: IStorageDriver, generateId?: boolean}`
      */
-    constructor(config: {storage: IStorageDriver, generateId?: boolean}) {
+    constructor(config: {storage: IStorageDriver}) {
         this.storage = config.storage;
-        this.generateId = config.generateId || true;
+        this.generateId = true;
 
         this.indices = new Map();
     }
@@ -52,9 +51,7 @@ export default class Datastore implements IDatastore {
      */
     public insert(doc: any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            if (this.generateId) {
-                doc._id = this.createId();
-            }
+            doc._id = this.createId();
 
             const indexPromises: Array<Promise<never>> = [];
 
@@ -214,17 +211,27 @@ export default class Datastore implements IDatastore {
 
     /**
      * Get Document by ID/s
+     * @param options - sort limit skip options
      * @param ids - ID or Array of IDs
      */
-    public getDocs(ids: string | string[]): Promise<any> {
+    public getDocs(options: Ioptions, ids: string | string[]): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            const idsArr: string[] = (typeof ids === "string") ? [ids] : ids;
+            let idsArr: string[] = (typeof ids === "string") ? [ids] : ids;
 
             const promises: Array<Promise<any>> = [];
 
-            idsArr.forEach((id) => {
-                promises.push(this.storage.getItem(id));
-            });
+            if (isEmpty(options)) {
+                this.createIdsArray(promises, idsArr);
+            } else if (options.skip && options.limit) {
+                idsArr = idsArr.slice(options.skip, options.limit + 1);
+                this.createIdsArray(promises, idsArr);
+            } else if (options.skip && !options.limit) {
+                idsArr.splice(0, options.skip);
+                this.createIdsArray(promises, idsArr);
+            } else if (options.limit && !options.skip) {
+                idsArr.slice(0, options.limit);
+                this.createIdsArray(promises, idsArr);
+            }
 
             Promise.all(promises)
                 .then(resolve)
@@ -407,6 +414,17 @@ export default class Datastore implements IDatastore {
                 })
                 .catch(reject);
             }
+        });
+    }
+
+    /**
+     * Return fill provided promise array with promises from the storage driver
+     * @param promises
+     * @param ids
+     */
+    private createIdsArray(promises: Array<Promise<any>>, ids: string[]): void {
+        ids.forEach((id) => {
+            promises.push(this.storage.getItem(id));
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,12 @@ import Cursor from "./cursor";
 import Index from "./indices";
 
 import { IIndex } from "./indices";
+import { Ioptions } from "./cursor";
 import { IDatastore } from "./datastore";
 import { IStorageDriver, IRange } from "./types";
 
 export { Datastore, IDatastore};
-export { Cursor };
+export { Cursor, Ioptions };
 export { Index, IIndex };
 export { IStorageDriver };
 export { IRange };

--- a/src/indices.ts
+++ b/src/indices.ts
@@ -4,7 +4,7 @@
 import { getPath } from "./utlis/get_path";
 import Datastore from "./datastore";
 import { IRange, IindexOptions } from "./types";
-import { compareArray } from "./utlis/compareArray";
+import { compareArray } from "./utlis";
 import * as BTT from "binary-type-tree";
 
 export interface IIndex {

--- a/src/utlis/index.ts
+++ b/src/utlis/index.ts
@@ -3,5 +3,5 @@ export { compareArray } from "./compareArray";
 export { decode, encode, getUUID, ByteBuffer, getDate } from "./id_hasher";
 export { getPath } from "./get_path";
 export { range } from "./range";
-export { isEmpty } from "./misc";
+export { isEmpty, mergeSort, getSortType } from "./misc";
 

--- a/src/utlis/misc.ts
+++ b/src/utlis/misc.ts
@@ -14,3 +14,70 @@ export const isEmpty = (obj: any) => {
 
     return false;
 };
+
+/**
+ * Get the type of element that will be sorted as `[object ${TYPE}]`
+ * @param arr - Array to check for type, will not send back a type if null or undefined
+ * @param field - field name to check against
+ * @returns {string}
+ */
+export const getSortType = (arr: any[], field: string): string => {
+    let type: string = "";
+    for (const doc of arr) {
+        if (doc.hasOwnProperty(field) && doc[field] !== null && doc[field] !== undefined) {
+            type = Object.prototype.toString.call(doc[field]);
+            break;
+        }
+    }
+    return type;
+};
+
+const merge = (left: any[], right: any[], sortField: string, sort: number, type: string) => {
+    const result = [];
+    const leftLength: number = left.length;
+    const rightLength: number = right.length;
+    let l: number = 0;
+    let r: number = 0;
+    // get the type of field. make sure to get the type from a document that has a filled result
+    if (type === "[object Date]" || type === "[object Number]" || type === "[object String]") {
+        if (sort === -1) {
+            while ( l < leftLength && r < rightLength) {
+                if (left[l][sortField] > right[r][sortField]) {
+                    result.push(left[l++]);
+                } else {
+                    result.push(right[r++]);
+                }
+            }
+        } else if (sort === 1) {
+            while ( l < leftLength && r < rightLength) {
+                if (left[l][sortField] < right[r][sortField]) {
+                    result.push(left[l++]);
+                } else {
+                    result.push(right[r++]);
+                }
+            }
+        }
+    } else {
+        throw new Error(`Sortable types are Date, String, and Number, this is not a sortable field, ${Object.prototype.toString.call(type)}`);
+    }
+    return result.concat(left.slice(l)).concat(right.slice(r));
+};
+
+/**
+ * Sort array of documents using MergeSort
+ * @param toSort - array of documents to sort
+ * @param sortField - field name as string from documents
+ * @param sortParam - numeric -1 for descending and 1 for ascending sort order
+ * @param type - one of the results of Object.prototype.toString.call(obj[field])
+ */
+export const mergeSort = (toSort: any[], sortField: string, sortParam: number, type: any): any => {
+    const len = toSort.length;
+    if (len < 2) {
+        return toSort;
+    }
+    const mid = Math.floor(len / 2);
+    const left = toSort.slice(0, mid);
+    const right = toSort.slice(mid);
+    return merge(mergeSort(left, sortField, sortParam, type), mergeSort(right, sortField, sortParam, type), sortField, sortParam, type);
+};
+


### PR DESCRIPTION
__Change Log:__
=

* Find + Cursor working and Tested
* New merge sort algo added for .sort on find
* .skip .limit are worked on the # of ids returned while .sort is worked on the returned documents. Sort can only sort values with String, Number, or Date.
* Ids are no longer optional. Ids are created for every collection item. 
* Iterator in the mock storage driver is now filled and is part of find.
* Update is the last piece of the database to be finished.